### PR TITLE
fixed git download url

### DIFF
--- a/src/main/resources/scripts/windowsInstallGitScript.ps1
+++ b/src/main/resources/scripts/windowsInstallGitScript.ps1
@@ -4,7 +4,7 @@ $latestRelease = Invoke-WebRequest -UseBasicParsing $source -Headers @{"Accept"=
 $json = $latestRelease.Content | ConvertFrom-Json
 $latestVersion = $json.tag_name
 $versionHead = $latestVersion.Substring(1, $latestVersion.IndexOf("windows")-2)
-$source = "https://github.com/git-for-windows/git/releases/download/v${versionHead}.windows.1/Git-${versionHead}-64-bit.exe"
+$source = "https://github.com/git-for-windows/git/releases/download/v${versionHead}.windows.2/Git-${versionHead}.1-64-bit.exe"
 $destination = "C:\Git-${versionHead}-64-bit.exe"
 $webClient = New-Object System.Net.WebClient
 $webClient.DownloadFile($source, $destination)


### PR DESCRIPTION
Every pipeline that depended on Git failed because they are failing to install Git and therefore nothing else will work. In the init.ps1 script they are attempting to download the installer from https://github.com/git-for-windows/git/releases/download/v2.24.1.windows.2/Git-2.24.1.1-64-bit.exe. This is not correct as the link is now https://github.com/git-for-windows/git/releases/download/v2.24.1.windows.2/Git-2.24.1.2-64-bit.exe